### PR TITLE
Dual setup fixes

### DIFF
--- a/python/configure/commands/remove_crontab.py
+++ b/python/configure/commands/remove_crontab.py
@@ -1,0 +1,44 @@
+import subprocess
+from typing import Any, Dict
+from .cmd import BaseCmd
+from .utils import run
+
+
+class RemoveCrontabCmd(BaseCmd):
+    """Command to remove the root crontab."""
+
+    def name(self) -> str:
+        return "Remove Crontab"
+
+    def description(self) -> str:
+        return "Removes the root user's crontab entries"
+
+    def execute(self, env: Dict[str, Any]) -> bool:
+        try:
+            # Check if there's an existing crontab
+            result = subprocess.run(
+                ["crontab", "-l"],
+                capture_output=True,
+                text=True
+            )
+
+            if result.returncode != 0:
+                print("No crontab found for root user. Nothing to remove.")
+                return True
+
+            # Show existing crontab before removal
+            print("Current crontab entries:")
+            print(result.stdout)
+
+            # Remove the crontab
+            print("Removing root crontab...")
+            run(["crontab", "-r"], check=True)
+            print("Root crontab removed successfully.")
+            return True
+
+        except subprocess.CalledProcessError as e:
+            print(f"Failed to remove crontab: {e}")
+            return False
+        except Exception as e:
+            print(f"Unexpected error removing crontab: {e}")
+            return False

--- a/python/configure/workflows/vm-and-docker-setup.yaml
+++ b/python/configure/workflows/vm-and-docker-setup.yaml
@@ -21,6 +21,8 @@ commands:
   - name: "GetIommuTypeCmd"
   - name: "GetGpuPciIdsCmd"
   - name: "AddGrubVirtualizationOptionsCmd"
+    environment:
+      skip_vfio_binding: true
   - name: "UpdateInitramfsModulesCmd"
   - name: "CreateVfioConfCmd"
   - name: "CreateNvidiaNoDrmConfCmd"

--- a/python/configure/workflows/vm-and-docker-setup.yaml
+++ b/python/configure/workflows/vm-and-docker-setup.yaml
@@ -2,6 +2,7 @@ name: "VM and Docker Configuration"
 description: "A workflow for configuring both virtual machine and Docker environments."
 
 commands:
+  - name: "RemoveCrontabCmd"
   - name: "CheckVirtualizationCmd"
   - name: "AptInstallCmd"
     environment:

--- a/python/configure/workflows/vm-only-setup.yaml
+++ b/python/configure/workflows/vm-only-setup.yaml
@@ -2,6 +2,7 @@ name: "VM-Only Configuration"
 description: "A workflow for configuring a virtual machine environment."
 
 commands:
+  - name: "RemoveCrontabCmd"
   - name: "CheckVirtualizationCmd"
   - name: "RemoveNvidiaDriverCmd"
   - name: "AptInstallCmd"


### PR DESCRIPTION
Two fixes:
- For dual NVIDIA / VFIO setup - don't blacklist NVIDIA drivers.
- Remove all crontab entries. Rohith uses the following crontab:
```
@reboot nvidia-smi -pm 1
@reboot nvidia-smi -pl 
@reboot screen -dmS gpuManger bash -c 'while true; do //set_fan_curve 60; sleep 1; done'
```
It runs set_fan_curve, which uses the Nvidia driver and blocks us from switching to VFIO. It is fine to remove it, since without the NVIDIA driver, set_fan_curve will not work, and we typically unload the NVIDIA driver anyway.

Not tested, unfortunately, as no node is available.