### PR TITLE
Update HWE kernel and ovmf

### DIFF
--- a/python/configure/commands/install_kernel.py
+++ b/python/configure/commands/install_kernel.py
@@ -1,0 +1,110 @@
+
+import subprocess
+from typing import Any, Dict
+from .cmd import BaseCmd
+from .utils import run
+
+
+# Minimum kernel branch required for reliable VFIO and NVIDIA GPU passthrough.
+MIN_KERNEL_BRANCH = (6, 8)
+
+# Package names per Ubuntu release codename.
+HWE_PACKAGES = {
+    "jammy": [
+        "linux-image-generic-hwe-22.04",
+        "linux-headers-generic-hwe-22.04",
+    ],
+}
+
+
+def get_running_kernel_version() -> str:
+    output, _, _ = run(["uname", "-r"], capture_output=True)
+    return output.strip()
+
+
+def parse_kernel_branch(version: str) -> tuple[int, ...]:
+    """Extract the (major, minor) tuple from a kernel version string like '6.8.0-100-generic'."""
+    parts = version.split(".")
+    try:
+        return (int(parts[0]), int(parts[1]))
+    except (IndexError, ValueError):
+        return (0, 0)
+
+
+def kernel_is_sufficient(version: str) -> bool:
+    return parse_kernel_branch(version) >= MIN_KERNEL_BRANCH
+
+
+def is_kernel_branch_installed(branch: tuple[int, ...]) -> bool:
+    """Check if a kernel from the target branch is already installed."""
+    branch_str = f"{branch[0]}.{branch[1]}"
+    output, _, rc = run(
+        ["dpkg", "-l", f"linux-image-{branch_str}.*-generic"],
+        capture_output=True, check=False, quiet_stderr=True,
+    )
+    return rc == 0 and "ii" in output
+
+
+def get_ubuntu_codename() -> str:
+    """Return the Ubuntu release codename (e.g. 'jammy', 'noble')."""
+    output, _, _ = run(
+        ["lsb_release", "-cs"],
+        capture_output=True, check=False, quiet_stderr=True,
+    )
+    return output.strip().lower()
+
+
+def install_hwe_kernel(codename: str) -> bool:
+    """Install the HWE kernel for the given Ubuntu release."""
+    packages = HWE_PACKAGES.get(codename)
+    if packages is None:
+        print(
+            f"No HWE kernel override configured for Ubuntu '{codename}'. "
+            f"The default kernel on this release should already be sufficient."
+        )
+        return True
+
+    print(f"Installing HWE kernel packages: {packages}")
+    run(["apt-get", "update"])
+    run(["apt-get", "install", "-y"] + packages)
+    print("HWE kernel installed successfully.")
+    return True
+
+
+class InstallHweKernelCmd(BaseCmd):
+    """Command to ensure a kernel >= 6.8 is installed for GPU passthrough."""
+
+    def name(self) -> str:
+        return "Install HWE Kernel"
+
+    def description(self) -> str:
+        branch_str = f"{MIN_KERNEL_BRANCH[0]}.{MIN_KERNEL_BRANCH[1]}"
+        return (
+            f"Ensures a kernel >= {branch_str} is installed "
+            f"for reliable IOMMU, VFIO, and NVIDIA GPU passthrough support."
+        )
+
+    def execute(self, env: Dict[str, Any]) -> bool:
+        current = get_running_kernel_version()
+        print(f"Current kernel: {current}")
+
+        if kernel_is_sufficient(current):
+            print(f"Kernel {current} meets the minimum requirement. Skipping.")
+            return True
+
+        if is_kernel_branch_installed(MIN_KERNEL_BRANCH):
+            branch_str = f"{MIN_KERNEL_BRANCH[0]}.{MIN_KERNEL_BRANCH[1]}"
+            print(
+                f"Kernel {branch_str}.x is installed but not running. "
+                "A reboot is needed."
+            )
+            return True
+
+        codename = get_ubuntu_codename()
+        print(f"Ubuntu release: {codename}")
+
+        try:
+            return install_hwe_kernel(codename)
+        except subprocess.CalledProcessError as e:
+            print(f"Failed to install HWE kernel: {e}")
+            return False

--- a/python/configure/commands/install_ovmf.py
+++ b/python/configure/commands/install_ovmf.py
@@ -112,21 +112,30 @@ def install_ovmf_from_noble() -> bool:
 
         # Fix up symlinks (the Noble package ships .ms.fd as a symlink to
         # .secboot.fd, but the Jammy package has them as separate files).
+        # Ensure each alias has the same content as its target.
         for link_name, target in OVMF_SYMLINKS.items():
             link_path = os.path.join(OVMF_DIR, link_name)
             target_path = os.path.join(OVMF_DIR, target)
             if not os.path.exists(target_path):
                 continue
+
+            # Resolve the effective content: follow symlinks for md5 check.
+            if os.path.exists(link_path):
+                real_link = os.path.realpath(link_path)
+                real_target = os.path.realpath(target_path)
+                if real_link == real_target or _file_md5(real_link) == _file_md5(real_target):
+                    print(f"  {link_name}: already matches {target}.")
+                    continue
+
             if os.path.islink(link_path):
                 os.remove(link_path)
             elif os.path.exists(link_path):
-                # Replace the regular file with the secboot content.
-                if _file_md5(link_path) != _file_md5(target_path):
-                    backup = link_path + ".bak"
-                    print(f"  {link_name}: backing up to {backup}")
-                    shutil.copy2(link_path, backup)
-                print(f"  {link_name}: replacing with {target}")
-                shutil.copy2(target_path, link_path)
+                backup = link_path + ".bak"
+                print(f"  {link_name}: backing up to {backup}")
+                shutil.copy2(link_path, backup)
+
+            print(f"  {link_name}: replacing with {target}")
+            shutil.copy2(target_path, link_path)
 
     print(f"OVMF {min_str} firmware files installed successfully.")
     return True

--- a/python/configure/commands/install_ovmf.py
+++ b/python/configure/commands/install_ovmf.py
@@ -1,0 +1,161 @@
+
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from typing import Any, Dict
+from .cmd import BaseCmd
+from .utils import run
+
+
+OVMF_DIR = "/usr/share/OVMF"
+OVMF_NOBLE_URL = (
+    "http://archive.ubuntu.com/ubuntu/pool/main/e/edk2/ovmf_2024.02-2_all.deb"
+)
+
+# Minimum required edk2 version (year, month).
+MIN_OVMF_VERSION = (2024, 2)
+
+# Files to upgrade from the Noble package.
+OVMF_FILES = [
+    "OVMF_CODE_4M.fd",
+    "OVMF_CODE_4M.secboot.fd",
+    "OVMF_VARS_4M.fd",
+    "OVMF_VARS_4M.ms.fd",
+]
+
+# Symlinks that should point at secboot after install.
+OVMF_SYMLINKS = {
+    "OVMF_CODE_4M.ms.fd": "OVMF_CODE_4M.secboot.fd",
+    "OVMF_CODE_4M.snakeoil.fd": "OVMF_CODE_4M.secboot.fd",
+}
+
+
+def parse_ovmf_version(version_str: str) -> tuple[int, int]:
+    """Parse an OVMF/edk2 version like '2024.02-2' into (2024, 2)."""
+    match = re.match(r"(\d{4})\.(\d{2})", version_str)
+    if match:
+        return (int(match.group(1)), int(match.group(2)))
+    return (0, 0)
+
+
+def get_installed_ovmf_version() -> str | None:
+    """Return the installed ovmf package version, or None."""
+    output, _, rc = run(
+        ["dpkg-query", "-W", "-f=${Version}", "ovmf"],
+        capture_output=True, check=False, quiet_stderr=True,
+    )
+    if rc != 0:
+        return None
+    return output.strip()
+
+
+def ovmf_needs_upgrade() -> bool:
+    """Check if the installed OVMF is older than the minimum required version."""
+    installed = get_installed_ovmf_version()
+    if installed is None:
+        print("OVMF package is not installed.")
+        return True
+    print(f"Installed OVMF package version: {installed}")
+    return parse_ovmf_version(installed) < MIN_OVMF_VERSION
+
+
+def _file_md5(path: str) -> str:
+    h = hashlib.md5()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def install_ovmf_from_noble() -> bool:
+    """Download the OVMF 2024.02 deb from Noble and install firmware files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        deb_path = os.path.join(tmpdir, "ovmf.deb")
+        extract_dir = os.path.join(tmpdir, "ovmf-extract")
+
+        min_str = f"{MIN_OVMF_VERSION[0]}.{MIN_OVMF_VERSION[1]:02d}"
+        print(f"Downloading OVMF {min_str} from Ubuntu Noble...")
+        run(["wget", "-q", "-O", deb_path, OVMF_NOBLE_URL])
+
+        print("Extracting package...")
+        os.makedirs(extract_dir)
+        run(["dpkg-deb", "-x", deb_path, extract_dir])
+
+        src_ovmf = os.path.join(extract_dir, "usr", "share", "OVMF")
+        if not os.path.isdir(src_ovmf):
+            print(f"Error: expected {src_ovmf} not found in package.")
+            return False
+
+        # Back up and replace each firmware file.
+        for fname in OVMF_FILES:
+            src = os.path.join(src_ovmf, fname)
+            dst = os.path.join(OVMF_DIR, fname)
+
+            if not os.path.exists(src):
+                print(f"  Warning: {fname} not found in package, skipping.")
+                continue
+
+            if os.path.exists(dst):
+                # Skip if identical.
+                if _file_md5(src) == _file_md5(dst):
+                    print(f"  {fname}: already up to date.")
+                    continue
+                backup = dst + ".bak"
+                print(f"  {fname}: backing up to {backup}")
+                shutil.copy2(dst, backup)
+
+            print(f"  {fname}: installing")
+            shutil.copy2(src, dst)
+
+        # Fix up symlinks (the Noble package ships .ms.fd as a symlink to
+        # .secboot.fd, but the Jammy package has them as separate files).
+        for link_name, target in OVMF_SYMLINKS.items():
+            link_path = os.path.join(OVMF_DIR, link_name)
+            target_path = os.path.join(OVMF_DIR, target)
+            if not os.path.exists(target_path):
+                continue
+            if os.path.islink(link_path):
+                os.remove(link_path)
+            elif os.path.exists(link_path):
+                # Replace the regular file with the secboot content.
+                if _file_md5(link_path) != _file_md5(target_path):
+                    backup = link_path + ".bak"
+                    print(f"  {link_name}: backing up to {backup}")
+                    shutil.copy2(link_path, backup)
+                print(f"  {link_name}: replacing with {target}")
+                shutil.copy2(target_path, link_path)
+
+    print(f"OVMF {min_str} firmware files installed successfully.")
+    return True
+
+
+class InstallOvmfCmd(BaseCmd):
+    """Command to install OVMF 2024.02+ firmware for modern GPU passthrough."""
+
+    def name(self) -> str:
+        return "Install OVMF Firmware"
+
+    def description(self) -> str:
+        min_str = f"{MIN_OVMF_VERSION[0]}.{MIN_OVMF_VERSION[1]:02d}"
+        return (
+            f"Ensures OVMF >= {min_str} is installed for reliable "
+            f"UEFI GPU passthrough with modern NVIDIA GPUs."
+        )
+
+    def execute(self, env: Dict[str, Any]) -> bool:
+        if not os.path.isdir(OVMF_DIR):
+            print(f"OVMF directory {OVMF_DIR} does not exist. Installing ovmf package first.")
+            run(["apt-get", "install", "-y", "ovmf"])
+
+        if not ovmf_needs_upgrade():
+            print("OVMF firmware is already sufficient. Skipping.")
+            return True
+
+        try:
+            return install_ovmf_from_noble()
+        except subprocess.CalledProcessError as e:
+            print(f"Failed to install OVMF: {e}")
+            return False

--- a/python/configure/commands/install_ovmf.py
+++ b/python/configure/commands/install_ovmf.py
@@ -5,6 +5,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import urllib.request
 from typing import Any, Dict
 from .cmd import BaseCmd
 from .utils import run
@@ -12,7 +13,7 @@ from .utils import run
 
 OVMF_DIR = "/usr/share/OVMF"
 OVMF_NOBLE_URL = (
-    "http://archive.ubuntu.com/ubuntu/pool/main/e/edk2/ovmf_2024.02-2_all.deb"
+    "https://archive.ubuntu.com/ubuntu/pool/main/e/edk2/ovmf_2024.02-2_all.deb"
 )
 
 # Minimum required edk2 version (year, month).
@@ -78,7 +79,7 @@ def install_ovmf_from_noble() -> bool:
 
         min_str = f"{MIN_OVMF_VERSION[0]}.{MIN_OVMF_VERSION[1]:02d}"
         print(f"Downloading OVMF {min_str} from Ubuntu Noble...")
-        run(["wget", "-q", "-O", deb_path, OVMF_NOBLE_URL])
+        urllib.request.urlretrieve(OVMF_NOBLE_URL, deb_path)
 
         print("Extracting package...")
         os.makedirs(extract_dir)
@@ -110,32 +111,32 @@ def install_ovmf_from_noble() -> bool:
             print(f"  {fname}: installing")
             shutil.copy2(src, dst)
 
-        # Fix up symlinks (the Noble package ships .ms.fd as a symlink to
-        # .secboot.fd, but the Jammy package has them as separate files).
-        # Ensure each alias has the same content as its target.
+        # Ensure each alias is a symlink to its target, matching Noble's layout.
         for link_name, target in OVMF_SYMLINKS.items():
             link_path = os.path.join(OVMF_DIR, link_name)
             target_path = os.path.join(OVMF_DIR, target)
             if not os.path.exists(target_path):
                 continue
 
-            # Resolve the effective content: follow symlinks for md5 check.
-            if os.path.exists(link_path):
-                real_link = os.path.realpath(link_path)
-                real_target = os.path.realpath(target_path)
-                if real_link == real_target or _file_md5(real_link) == _file_md5(real_target):
-                    print(f"  {link_name}: already matches {target}.")
-                    continue
+            if os.path.lexists(link_path):
+                # If it's already a symlink that resolves to the same target, keep it.
+                if os.path.islink(link_path):
+                    real_link = os.path.realpath(link_path)
+                    real_target = os.path.realpath(target_path)
+                    if real_link == real_target:
+                        print(f"  {link_name}: already matches {target}.")
+                        continue
+                    else:
+                        os.remove(link_path)
+                else:
+                    # Back up existing non-symlink before replacing.
+                    backup = link_path + ".bak"
+                    print(f"  {link_name}: backing up to {backup}")
+                    shutil.copy2(link_path, backup)
+                    os.remove(link_path)
 
-            if os.path.islink(link_path):
-                os.remove(link_path)
-            elif os.path.exists(link_path):
-                backup = link_path + ".bak"
-                print(f"  {link_name}: backing up to {backup}")
-                shutil.copy2(link_path, backup)
-
-            print(f"  {link_name}: replacing with {target}")
-            shutil.copy2(target_path, link_path)
+            print(f"  {link_name}: creating symlink to {target}")
+            os.symlink(target, link_path)
 
     print(f"OVMF {min_str} firmware files installed successfully.")
     return True
@@ -157,6 +158,7 @@ class InstallOvmfCmd(BaseCmd):
     def execute(self, env: Dict[str, Any]) -> bool:
         if not os.path.isdir(OVMF_DIR):
             print(f"OVMF directory {OVMF_DIR} does not exist. Installing ovmf package first.")
+            run(["apt-get", "update"])
             run(["apt-get", "install", "-y", "ovmf"])
 
         if not ovmf_needs_upgrade():

--- a/python/configure/commands/install_qemu.py
+++ b/python/configure/commands/install_qemu.py
@@ -1,0 +1,168 @@
+
+import os
+import re
+import subprocess
+from typing import Any, Dict
+from .cmd import BaseCmd
+from .utils import run
+
+
+# Minimum required versions.
+MIN_QEMU_VERSION = (9, 0)
+MIN_LIBVIRT_VERSION = (10, 6)
+
+# Canonical Server Backports PPA (supports Jammy and Noble).
+BACKPORTS_PPA = "ppa:canonical-server/server-backports"
+
+# Packages to upgrade.
+QEMU_PACKAGES = [
+    "qemu-system-x86",
+    "qemu-block-extra",
+    "qemu-system-common",
+    "qemu-system-data",
+    "qemu-system-gui",
+    "qemu-utils",
+]
+
+LIBVIRT_PACKAGES = [
+    "libvirt-daemon-system",
+    "libvirt-daemon-driver-qemu",
+    "libvirt-clients",
+]
+
+
+def parse_qemu_version(version_str: str) -> tuple[int, int]:
+    """Parse QEMU version like '9.0.2' or 'QEMU emulator version 9.0.2 ...' into (9, 0)."""
+    match = re.search(r"(\d+)\.(\d+)", version_str)
+    if match:
+        return (int(match.group(1)), int(match.group(2)))
+    return (0, 0)
+
+
+def parse_libvirt_version(version_str: str) -> tuple[int, int]:
+    """Parse libvirt version like '10.6.0' into (10, 6)."""
+    match = re.search(r"(\d+)\.(\d+)", version_str)
+    if match:
+        return (int(match.group(1)), int(match.group(2)))
+    return (0, 0)
+
+
+def get_installed_qemu_version() -> str | None:
+    """Return the installed QEMU version string, or None."""
+    output, _, rc = run(
+        ["qemu-system-x86_64", "--version"],
+        capture_output=True, check=False, quiet_stderr=True,
+    )
+    if rc != 0:
+        return None
+    return output.strip()
+
+
+def get_installed_libvirt_version() -> str | None:
+    """Return the installed libvirt version string, or None."""
+    output, _, rc = run(
+        ["virsh", "--version"],
+        capture_output=True, check=False, quiet_stderr=True,
+    )
+    if rc != 0:
+        return None
+    return output.strip()
+
+
+def qemu_needs_upgrade() -> bool:
+    """Check if installed QEMU is older than the minimum required version."""
+    installed = get_installed_qemu_version()
+    if installed is None:
+        print("QEMU is not installed.")
+        return True
+    version = parse_qemu_version(installed)
+    print(f"Installed QEMU version: {version[0]}.{version[1]}")
+    return version < MIN_QEMU_VERSION
+
+
+def libvirt_needs_upgrade() -> bool:
+    """Check if installed libvirt is older than the minimum required version."""
+    installed = get_installed_libvirt_version()
+    if installed is None:
+        print("libvirt is not installed.")
+        return True
+    version = parse_libvirt_version(installed)
+    print(f"Installed libvirt version: {version[0]}.{version[1]}")
+    return version < MIN_LIBVIRT_VERSION
+
+
+def is_ppa_configured() -> bool:
+    """Check if the Canonical Server Backports PPA is already configured."""
+    output, _, rc = run(
+        ["grep", "-r", "canonical-server/server-backports",
+         "/etc/apt/sources.list.d/"],
+        capture_output=True, check=False, quiet_stderr=True,
+    )
+    return rc == 0 and len(output) > 0
+
+
+def add_backports_ppa() -> None:
+    """Add the Canonical Server Backports PPA."""
+    if is_ppa_configured():
+        print("Canonical Server Backports PPA is already configured.")
+        return
+    print("Adding Canonical Server Backports PPA...")
+    run(["add-apt-repository", "-y", BACKPORTS_PPA])
+
+
+def upgrade_packages(packages: list[str]) -> None:
+    """Upgrade the specified packages from the backports PPA."""
+    os.environ["DEBIAN_FRONTEND"] = "noninteractive"
+    run(["apt-get", "update", "-qq"])
+    run([
+        "apt-get", "install", "-y",
+        "-o", "Dpkg::Options::=--force-confold",
+    ] + packages)
+
+
+class UpgradeQemuCmd(BaseCmd):
+    """Command to upgrade QEMU and libvirt for modern GPU passthrough."""
+
+    def name(self) -> str:
+        return "Upgrade QEMU and libvirt"
+
+    def description(self) -> str:
+        qemu_str = f"{MIN_QEMU_VERSION[0]}.{MIN_QEMU_VERSION[1]}"
+        libvirt_str = f"{MIN_LIBVIRT_VERSION[0]}.{MIN_LIBVIRT_VERSION[1]}"
+        return (
+            f"Ensures QEMU >= {qemu_str} and libvirt >= {libvirt_str} "
+            f"are installed for reliable GPU passthrough with modern GPUs."
+        )
+
+    def execute(self, env: Dict[str, Any]) -> bool:
+        need_qemu = qemu_needs_upgrade()
+        need_libvirt = libvirt_needs_upgrade()
+
+        if not need_qemu and not need_libvirt:
+            print("QEMU and libvirt are already sufficient. Skipping.")
+            return True
+
+        packages = []
+        if need_qemu:
+            packages.extend(QEMU_PACKAGES)
+        if need_libvirt:
+            packages.extend(LIBVIRT_PACKAGES)
+
+        try:
+            add_backports_ppa()
+            print(f"Upgrading packages: {packages}")
+            upgrade_packages(packages)
+
+            # Restart libvirtd to pick up the new version.
+            print("Restarting libvirtd...")
+            run(["systemctl", "restart", "libvirtd"])
+
+            # Verify.
+            qemu_ver = get_installed_qemu_version()
+            libvirt_ver = get_installed_libvirt_version()
+            print(f"QEMU after upgrade: {qemu_ver}")
+            print(f"libvirt after upgrade: {libvirt_ver}")
+            return True
+        except subprocess.CalledProcessError as e:
+            print(f"Failed to upgrade QEMU/libvirt: {e}")
+            return False

--- a/python/configure/workflows/vm-and-docker-setup.yaml
+++ b/python/configure/workflows/vm-and-docker-setup.yaml
@@ -14,6 +14,7 @@ commands:
         - "mdadm"
   - name: "InstallHweKernelCmd"
   - name: "InstallOvmfCmd"
+  - name: "UpgradeQemuCmd"
   - name: "RemoveGrubOverrideCmd"
   - name: "InstallNvidiaDriverCmd"
   - name: "ConfigureDockerCmd"

--- a/python/configure/workflows/vm-and-docker-setup.yaml
+++ b/python/configure/workflows/vm-and-docker-setup.yaml
@@ -12,6 +12,8 @@ commands:
         - "genisoimage"
         - "whois"
         - "mdadm"
+  - name: "InstallHweKernelCmd"
+  - name: "InstallOvmfCmd"
   - name: "RemoveGrubOverrideCmd"
   - name: "InstallNvidiaDriverCmd"
   - name: "ConfigureDockerCmd"

--- a/python/configure/workflows/vm-only-setup.yaml
+++ b/python/configure/workflows/vm-only-setup.yaml
@@ -15,6 +15,7 @@ commands:
         - "mdadm"
   - name: "InstallHweKernelCmd"
   - name: "InstallOvmfCmd"
+  - name: "UpgradeQemuCmd"
   - name: "ConfigureDockerCmd"
   - name: "ConfigureLibvirtCmd"
   - name: "ReadGrubCmd"

--- a/python/configure/workflows/vm-only-setup.yaml
+++ b/python/configure/workflows/vm-only-setup.yaml
@@ -13,6 +13,8 @@ commands:
         - "genisoimage"
         - "whois"
         - "mdadm"
+  - name: "InstallHweKernelCmd"
+  - name: "InstallOvmfCmd"
   - name: "ConfigureDockerCmd"
   - name: "ConfigureLibvirtCmd"
   - name: "ReadGrubCmd"


### PR DESCRIPTION
EFI bios requires newer kernel and newer OVMF files. Older QEMU also crashes during GPU passthrough with modern GPUs.

## Changes
- **HWE kernel 6.8**: Install HWE kernel on Ubuntu 22.04 for improved IOMMU/VFIO support
- **OVMF 2024.02**: Upgrade OVMF firmware to fix UEFI boot hangs with RTX 40-series GPUs
- **QEMU 9.0 + libvirt 10.6**: Upgrade from Canonical Server Backports PPA to fix GPU passthrough crashes (e.g. AMD MI350X pci_irq_handler assertion failure in QEMU 6.2)

All three commands are no-ops on Ubuntu 24.04+ where defaults already meet the requirements.